### PR TITLE
[-] FO : Correct IE8 syntax error

### DIFF
--- a/js/ajax-wishlist.js
+++ b/js/ajax-wishlist.js
@@ -302,7 +302,7 @@ function WishlistDefault(id, id_wishlist)
 		cache: false,
 		data: {
 			rand:new Date().getTime(),
-			default: 1,
+			'default': 1,
 			id_wishlist:id_wishlist,
 			myajax: 1,
 			action: 'setdefault'


### PR DESCRIPTION
In Internet Explorer version 8 and older, having a property called "default" (technically a reserved word) defined as a bare word throws a syntax error and halts script execution. If you happen to be using CCC, this will break all Javascript on your entire site. Wrapping the property name in quotes fixes the issue.