### PR TITLE
Replace $base_dir by $content_dir

### DIFF
--- a/views/templates/front/mywishlist.tpl
+++ b/views/templates/front/mywishlist.tpl
@@ -113,6 +113,6 @@
 
 	<ul class="footer_links">
 		<li><a href="{$link->getPageLink('my-account', true)}"><img src="{$img_dir}icon/my-account.gif" alt="" class="icon" /></a><a href="{$link->getPageLink('my-account', true)|escape:'html'}">{l s='Back to Your Account' mod='blockwishlist'}</a></li>
-		<li class="f_right"><a href="{$base_dir}"><img src="{$img_dir}icon/home.gif" alt="" class="icon" /></a><a href="{$base_dir}">{l s='Home' mod='blockwishlist'}</a></li>
+		<li class="f_right"><a href="{$content_dir}"><img src="{$img_dir}icon/home.gif" alt="" class="icon" /></a><a href="{$base_dir}">{l s='Home' mod='blockwishlist'}</a></li>
 	</ul>
 </div>


### PR DESCRIPTION
For full SSL shop, $base_dir return root folder without SSL. Use $content_dir instead.
