### PR TITLE
Make module prop public

### DIFF
--- a/controllers/front/view.php
+++ b/controllers/front/view.php
@@ -30,9 +30,12 @@ use PrestaShop\PrestaShop\Core\Product\Search\SortOrderFactory;
 class BlockWishlistViewModuleFrontController extends ProductListingFrontController
 {
     /**
+     * Made public as the core considers this class as an ModuleFrontController
+     * and other modules expects to find the $module property.
+     *
      * @var BlockWishList
      */
-    private $module;
+    public $module;
 
     /**
      * @var WishList


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Declare `$module` var as public in ProductListingController
| Type?         | bug fix
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Having PsPixel and BlockWishlist does not trigger any issue

Fixing:
![image](https://user-images.githubusercontent.com/6768917/88397009-9f1cc100-cdc3-11ea-8f4d-9984ae165fc5.png)
