### PR TITLE
Create database tables during upgrade from PS 1.6

### DIFF
--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -62,11 +62,6 @@ class BlockWishList extends Module
         ],
     ];
 
-    /**
-     * @var bool
-     */
-    public $isPrestaShopVersionLessThan176;
-
     public function __construct()
     {
         $this->name = 'blockwishlist';
@@ -83,7 +78,6 @@ class BlockWishList extends Module
             'min' => '1.7.6.0',
             'max' => _PS_VERSION_,
         ];
-        $this->isPrestaShopVersionLessThan176 = (bool) version_compare(_PS_VERSION_, '1.7.6', '<');
     }
 
     /**
@@ -214,7 +208,6 @@ class BlockWishList extends Module
     {
         $this->smarty->assign([
             'blockwishlist' => $this->displayName,
-            'isPrestaShopVersionLessThan176' => $this->isPrestaShopVersionLessThan176,
         ]);
 
         return $this->fetch('module:blockwishlist/views/templates/hook/displayAdminCustomers.tpl');

--- a/upgrade/upgrade-2.0.0.php
+++ b/upgrade/upgrade-2.0.0.php
@@ -17,6 +17,9 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
+use PrestaShop\Module\BlockWishList\Database\Install;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -28,6 +31,10 @@ if (!defined('_PS_VERSION_')) {
  */
 function upgrade_module_2_0_0($module)
 {
+    if (false === (new Install($module->getTranslator()))->run()) {
+        return false;
+    }
+
     $products = Db::getInstance()->executeS(
         'SELECT wp.`id_product`, wp.`id_product_attribute`
         FROM `' . _DB_PREFIX_ . 'wishlist_product` wp'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | For merchants upgrading from PS 1.6, the module could not be used
| Type?         | bug fix
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Install PrestaShop 1.6 and the blockwishlist module. Configure it for a user, then upgrade to PrestaShop 1.7. Uploading the latest module will set the new data for PS 1.7 and keep the existing wishlists.