### PR TITLE
Avoid negative or zero values as quantity

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,10 +1,6 @@
 name: Build & Release draft
 
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   deploy:
@@ -52,7 +48,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     needs: [deploy]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v1

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -49,4 +49,4 @@ jobs:
         run: docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/prestashop:${{ matrix.presta-versions }}
 
       - name : Run PHPStan
-        run: docker run --rm --volumes-from temp-ps -v $PWD:/web/module -e _PS_ROOT_DIR_=/var/www/html --workdir=/web/module phpstan/phpstan:0.12 analyse --configuration=/web/module/tests/phpstan/phpstan.neon --error-format github
+        run: docker run --rm --volumes-from temp-ps -v $PWD:/web/module -e _PS_ROOT_DIR_=/var/www/html --workdir=/web/module phpstan/phpstan:0.12.32 analyse --configuration=/web/module/tests/phpstan/phpstan.neon --error-format github

--- a/classes/WishList.php
+++ b/classes/WishList.php
@@ -425,9 +425,12 @@ class WishList extends ObjectModel
             return false;
         }
 
+        $newQuantity = (int) $result['quantity'] - (int) $quantity;
+        $minimalQuantity = self::getMinimalProductQuantity($id_product, $id_product_attribute);
+
         return Db::getInstance()->execute('
             UPDATE `' . _DB_PREFIX_ . 'wishlist_product` SET
-            `quantity` = ' . (int) ($result['quantity'] - $quantity) . '
+            `quantity` = ' . (int) max($minimalQuantity, $newQuantity) . '
             WHERE `id_wishlist` = ' . (int) $id_wishlist . '
             AND `id_product` = ' . (int) $id_product . '
             AND `id_product_attribute` = ' . (int) $id_product_attribute);
@@ -613,5 +616,23 @@ class WishList extends ObjectModel
         }
 
         return Cache::retrieve($cache_id);
+    }
+
+    /**
+     * @param int $idProduct
+     * @param int $idAttribute
+     *
+     * @return int
+     */
+    private static function getMinimalProductQuantity($idProduct, $idAttribute)
+    {
+        if ($idAttribute) {
+            $minimalQuantity = Attribute::getAttributeMinimalQty($idAttribute);
+            if (false !== $minimalQuantity) {
+                return (int) $minimalQuantity;
+            }
+        }
+
+        return (int) (new Product($idProduct))->minimal_quantity;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When a product inside a wishlist has been added to the cart, reset its quantity to 1 instead of zero.
| Type?         | bug fix
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Adding a product in the cart from the wishlist page updates its quantity to 1.