### PR TITLE
Filter on current shop when displaying products in wishlist

### DIFF
--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -129,7 +129,7 @@ class BlockWishList extends Module
     public function hookActionFrontControllerSetMedia(array $params)
     {
         $productsTagged = true === $this->context->customer->isLogged()
-            ? WishList::getAllProductByCustomer($this->context->customer->id)
+            ? WishList::getAllProductByCustomer($this->context->customer->id, $this->context->shop->id)
             : false;
 
         Media::addJsDef([

--- a/classes/WishList.php
+++ b/classes/WishList.php
@@ -441,13 +441,14 @@ class WishList extends ObjectModel
      *
      * @return array|false
      */
-    public static function getAllProductByCustomer($id_customer)
+    public static function getAllProductByCustomer($id_customer, $idShop)
     {
         $result = Db::getInstance()->executeS('
             SELECT  `id_product`, `id_product_attribute`, w.`id_wishlist`, wp.`quantity`
             FROM `' . _DB_PREFIX_ . 'wishlist_product` wp
             LEFT JOIN `' . _DB_PREFIX_ . 'wishlist` w ON (w.`id_wishlist` = wp.`id_wishlist`)
             WHERE w.`id_customer` = ' . (int) $id_customer . '
+            AND w.id_shop = ' . (int) $idShop . '
             AND wp.`quantity` > 0 ');
 
         if (empty($result)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR fixes the value of ![image](https://user-images.githubusercontent.com/6768917/95361755-0d522980-08c5-11eb-9ef5-b6cb9c47d987.png) in the product lists, when using multishop.
| Type?         | bug fix
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Even if we share products between shops in a multishop context, a product added in a shop should not have any impact on the other one.