### PR TITLE
Get cover image for specific combination

### DIFF
--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -130,6 +130,9 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
                 )
             ) > 0 AS new'
             );
+            $querySearch->select('
+                (SELECT `id_image` FROM `' . _DB_PREFIX_ . 'product_attribute_image` WHERE `id_product_attribute` = product_attribute_shop.`id_product_attribute`) cover_image_id'
+            );
             if (Combination::isFeatureActive()) {
                 $querySearch->select('product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.`id_product_attribute`,0) AS id_product_attribute');
             }
@@ -169,24 +172,10 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
             $querySearch->orderBy($sortOrder . ' ' . $query->getSortOrder()->toLegacyOrderWay());
             $querySearch->limit(((int) $query->getPage() - 1) * (int) $query->getResultsPerPage(), (int) $query->getResultsPerPage());
             $products = $this->db->executeS($querySearch);
-
+            
             if (empty($products)) {
                 return [];
             }
-
-            $products = array_map(
-                function ($product) {
-                    if (0 < (int) $product['id_product_attribute']) {
-                        $combinationImages = Product::_getAttributeImageAssociations($product['id_product_attribute']);
-                        if ($combinationImages && isset($combinationImages[0])) {
-                            $product['cover_image_id'] = $combinationImages[0];
-                        }
-                    }
-
-                    return $product;
-                },
-                $products
-            );
 
             return Product::getProductsProperties((int) $context->getIdLang(), $products);
         }

--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -178,7 +178,7 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
                 function ($product) {
                     if (0 < (int) $product['id_product_attribute']) {
                         $combinationImages = Product::_getAttributeImageAssociations($product['id_product_attribute']);
-                        if (count($combinationImages)) {
+                        if ($combinationImages && isset($combinationImages[0])) {
                             $product['cover_image_id'] = $combinationImages[0];
                         }
                     }

--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -172,7 +172,7 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
             $querySearch->orderBy($sortOrder . ' ' . $query->getSortOrder()->toLegacyOrderWay());
             $querySearch->limit(((int) $query->getPage() - 1) * (int) $query->getResultsPerPage(), (int) $query->getResultsPerPage());
             $products = $this->db->executeS($querySearch);
-            
+
             if (empty($products)) {
                 return [];
             }

--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -182,6 +182,7 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
                             $product['cover_image_id'] = $combinationImages[0];
                         }
                     }
+
                     return $product;
                 },
                 $products

--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -176,7 +176,7 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
 
             $products = array_map(
                 function ($product) {
-                    if (0 < $product['id_product_attribute']) {
+                    if (0 < (int) $product['id_product_attribute']) {
                         $combinationImages = Product::_getAttributeImageAssociations($product['id_product_attribute']);
                         if (count($combinationImages)) {
                             $product['cover_image_id'] = $combinationImages[0];

--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -174,6 +174,19 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
                 return [];
             }
 
+            $products = array_map(
+                function ($product) {
+                    if (0 < $product['id_product_attribute']) {
+                        $combinationImages = Product::_getAttributeImageAssociations($product['id_product_attribute']);
+                        if (count($combinationImages)) {
+                            $product['cover_image_id'] = $combinationImages[0];
+                        }
+                    }
+                    return $product;
+                },
+                $products
+            );
+
             return Product::getProductsProperties((int) $context->getIdLang(), $products);
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Get cover for selected combination instead of default cover
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | If you add white t-shirt, you should have a photo of white t-shirt, not default black one
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
