### PR TITLE
Update Parent tab to highlight Modules when on the configuration page

### DIFF
--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -45,7 +45,7 @@ class BlockWishList extends Module
         [
             'class_name' => 'WishlistConfigurationAdminParentController',
             'visible' => false,
-            'parent_class_name' => 'AdminModulesSf',
+            'parent_class_name' => 'AdminParentModulesSf',
             'name' => 'Wishlist Module',
         ],
         [


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | After merging #91, the tabs were not appearing anymore on the backoffice. This PR fixes the issue
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| How to test?      | Pull this PR, resinstall the module and check the configuration page of wishlist. The tabs should be visible at the top of the page
| Possible impacts? | None