### PR TITLE
Fix closing 'a' tag, fixes #24922

### DIFF
--- a/views/templates/hook/account/myaccount-block.tpl
+++ b/views/templates/hook/account/myaccount-block.tpl
@@ -21,6 +21,6 @@
   <li>
     <a href="{$url}" title="{$wishlistsTitlePage}" rel="nofollow">
       {$blockwishlist|escape:'html':'UTF-8'}
-    <a>
+    </a>
   </li>
 {/if}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix closing `a` tag
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/24922
| How to test?      | Check that the tag is closed... Details in #122 
| Possible impacts? | 

