### PR TITLE
Extend addedToWishlist by chosen product attribute id

### DIFF
--- a/_dev/front/js/components/Button/Button.vue
+++ b/_dev/front/js/components/Button/Button.vue
@@ -137,7 +137,7 @@
        * Register to event addedToWishlist to toggle the heart if the product has been added correctly
        */
       EventBus.$on('addedToWishlist', (event) => {
-        if (event.detail.productId === this.productId) {
+        if (event.detail.productId === this.productId && event.detail.productAttributeId === this.productAttributeId) {
           this.isChecked = true;
           this.idList = event.detail.listId;
         }

--- a/_dev/front/js/components/ChooseList/ChooseList.vue
+++ b/_dev/front/js/components/ChooseList/ChooseList.vue
@@ -174,7 +174,11 @@
          * Send an event to the Heart the user previously clicked on
          */
         EventBus.$emit('addedToWishlist', {
-          detail: {productId: this.productId, listId},
+          detail: {
+            productId: this.productId,
+            listId,
+            productAttributeId: this.productAttributeId,
+          },
         });
       },
     },


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Extends addedToWishlist event by data required to identify clearly added product
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Listen over `window.WishlistEventBus` and print params
| Possible impacts? | No one


