### PR TITLE
Fix Add to Wishlist not initialized on Manufacturer page

### DIFF
--- a/views/templates/hook/displayHeader.tpl
+++ b/views/templates/hook/displayHeader.tpl
@@ -24,7 +24,7 @@
   {include file="module:blockwishlist/views/templates/components/toast.tpl"}
 {/if}
 
-{if $context === "index" || $context === "category" || $context === "blockwishlist" || $context === 'search'}
+{if $context === "index" || $context === "category" || $context === "blockwishlist" || $context === 'search' || $context === 'manufacturer'}
   {include file="module:blockwishlist/views/templates/components/modals/add-to-wishlist.tpl" url=$url addUrl=$addUrl newWishlistCTA=$newWishlistCTA}
   {include file="module:blockwishlist/views/templates/components/modals/create.tpl" url=$createUrl}
   {include file="module:blockwishlist/views/templates/components/modals/delete.tpl" productUrl=$deleteProductUrl}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Can't add to wishlist on Manufacturer controller cause is not initialized. Check issue: https://github.com/PrestaShop/PrestaShop/issues/26755
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26755.
| How to test?      | Go to Manufacturer page, and click on the Wishlist button (Logged or unlogged)
| Possible impacts? | Nothing.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
