### PR TITLE
Add help sidebar to the statistic page

### DIFF
--- a/src/Controller/WishlistConfigurationAdminController.php
+++ b/src/Controller/WishlistConfigurationAdminController.php
@@ -85,6 +85,8 @@ class WishlistConfigurationAdminController extends FrameworkBundleAdminControlle
             'currentMonthStatisticsGrid' => $this->presentGrid($currentMonthGrid),
             'currentDayStatisticsGrid' => $this->presentGrid($currentDayGrid),
             'shopId' => $this->shopId,
+            'enableSidebar' => true,
+            'help_link' => $this->generateSidebarLink('WishlistConfigurationAdminController'),
         ]);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Help sidebar was disabled on statistics page
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27134.
| How to test?      | Go on statistic page in the BO and try to click on the help button

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
