### PR TITLE
Refacto card-block to card-body

### DIFF
--- a/views/templates/admin/home.html.twig
+++ b/views/templates/admin/home.html.twig
@@ -27,8 +27,8 @@
             <i class="material-icons">edit</i> {{ 'Wording'|trans({}, 'Modules.Blockwishlist.Admin') }}
           </h3>
 
-          <div class="card-block row">
-            <div class="card-text">
+          <div class="card-body">
+            <div class="form-wrapper">
               {{ form_widget(configurationForm) }}
             </div>
           </div>

--- a/views/templates/admin/statistics.html.twig
+++ b/views/templates/admin/statistics.html.twig
@@ -34,7 +34,7 @@
           <i class="material-icons">star</i> {{ 'Top 10 most added products'|trans({}, 'Modules.Blockwishlist.Admin') }}
         </h3>
 
-        <div class="card-block">
+        <div class="card-body">
           <div class="card-text">
             <div class="row wishlist-stats-topbar">
               <div class="btn-group">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | card-block is not existing, it should be card-body
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/pull/25879#pullrequestreview-857500621.
| How to test?      | See issue, it's all about the configuration page markup
| Possible impacts? | configuration page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
