### PR TITLE
Make compatible with user account menu

### DIFF
--- a/views/templates/pages/lists.tpl
+++ b/views/templates/pages/lists.tpl
@@ -16,7 +16,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-{extends file='page.tpl'}
+{extends file='customer/page.tpl'}
 
 {block name='page_header_container'}
 {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Most of third-party themes (as like as theme-refacto) implements the account menu in "My Account" page. The blockwishlist should display this menu for list page. 
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | https://github.com/PrestaShop/blockwishlist/pull/157#issuecomment-1017442909
| Possible impacts? | The blockwishlist page in "My Account" (Doesn't impact classic theme).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

**Current:**
![Screenshot 2022-01-20 at 11-58-56 Wishlist](https://user-images.githubusercontent.com/85633460/150335856-a9de6547-23a6-4fb8-a969-5e3c041c65bd.png)


**Expected:**
![Screenshot 2022-01-20 at 11-58-42 Wishlist](https://user-images.githubusercontent.com/85633460/150335887-c3bc0436-6c0c-4b26-aa1b-782b1288651a.png)
