### PR TITLE
Fix alert message width for theme-refacto

### DIFF
--- a/_dev/front/js/components/Toast/Toast.vue
+++ b/_dev/front/js/components/Toast/Toast.vue
@@ -101,6 +101,7 @@
     &-toast {
       padding: 0.875rem 1.25rem;
       box-sizing: border-box;
+      width: auto;
       border: 1px solid #e5e5e5;
       border-radius: 4px;
       background-color: #ffffff;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix the width of toasts for theme-refacto.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | https://github.com/PrestaShop/blockwishlist/pull/158#issuecomment-1017511633
| Possible impacts? | The blockwishlist alerts in theme-refacto (Doesn't impact on classic theme).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


**Current:**
![Screenshot 2022-01-20 at 13-27-35 Hummingbird printed sweater](https://user-images.githubusercontent.com/85633460/150348464-0cc69537-163b-463d-9f61-940fed00933c.png)

**Expected:**
![Screenshot 2022-01-20 at 13-28-28 Hummingbird printed sweater](https://user-images.githubusercontent.com/85633460/150348509-06bac464-f131-4e42-9b63-da72422a6107.png)
