### PR TITLE
Remove unneeded import in product list

### DIFF
--- a/views/templates/pages/products-list.tpl
+++ b/views/templates/pages/products-list.tpl
@@ -38,8 +38,6 @@
   </div>
 
   {include file="module:blockwishlist/views/templates/components/pagination.tpl"}
-  {include file="module:blockwishlist/views/templates/components/modals/delete.tpl" deleteProductUrl=$deleteProductUrl}
-  {include file="module:blockwishlist/views/templates/components/toast.tpl"}
 {/block}
 
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Modals were imported 2 times in product list of wishlist
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27327.
| How to test?      | See issue
| Possible impacts? | Wishlist product list

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
