### PR TITLE
Removed the hook displayProductAdditionalInfo as the hook listener is not defined

### DIFF
--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -40,7 +40,6 @@ class BlockWishList extends Module
         'displayCustomerAccount',
         'displayFooter',
         'displayAdminCustomers',
-        'displayProductAdditionalInfo',
         'displayMyAccountBlock',
     ];
 

--- a/upgrade/upgrade-2.1.0.php
+++ b/upgrade/upgrade-2.1.0.php
@@ -25,6 +25,7 @@
  */
 function upgrade_module_2_1_0($module)
 {
-    return $module->registerHook('displayFooter') &&
-        $module->unregisterHook('displayHeader');
+    return $module->registerHook('displayFooter')
+        && $module->unregisterHook('displayHeader')
+        && $module->unregisterHook('displayProductAdditionalInfo');
 }


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Removed the hook displayProductAdditionalInfo as the hook listener is not defined
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Relative to PrestaShop/PrestaShop#19230
| How to test?      | Install this branch<br>`blockwishlist` is not linked to the hook `displayProductAdditionalInfo`<br>In upgrade, the hook `displayProductAdditionalInfo` is unlinked.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
