### PR TITLE
Fix multiple modal open on wishlist list page

### DIFF
--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -261,6 +261,7 @@ class BlockWishList extends Module
         $this->smarty->assign([
             'context' => $this->context->controller->php_self,
             'url' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'getAllWishlist']),
+            'deleteListUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'deleteWishlist']),
             'createUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'createNewWishlist']),
             'deleteProductUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'deleteProductFromWishlist']),
             'addUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'addProductToWishlist']),

--- a/controllers/front/lists.php
+++ b/controllers/front/lists.php
@@ -28,21 +28,6 @@ class BlockWishlistListsModuleFrontController extends ModuleFrontController
     {
         parent::initContent();
 
-        $this->context->smarty->assign(
-        [
-            'url' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'getAllWishlist']),
-            'createUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'createNewWishlist']),
-            'deleteListUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'deleteWishlist']),
-            'deleteProductUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'deleteProductFromWishlist']),
-            'renameUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'renameWishlist']),
-            'shareUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'getUrlByIdWishlist']),
-            'addUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'addProductToWishlist']),
-            'accountLink' => '#',
-            'wishlistsTitlePage' => Configuration::get('blockwishlist_WishlistPageName', $this->context->language->id),
-            'newWishlistCTA' => Configuration::get('blockwishlist_CreateButtonLabel', $this->context->language->id),
-        ]
-      );
-
         $this->context->controller->registerJavascript(
           'blockwishlistController',
           'modules/blockwishlist/public/wishlistcontainer.bundle.js',

--- a/controllers/front/lists.php
+++ b/controllers/front/lists.php
@@ -28,6 +28,15 @@ class BlockWishlistListsModuleFrontController extends ModuleFrontController
     {
         parent::initContent();
 
+        $this->context->smarty->assign(
+        [
+            'url' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'getAllWishlist']),
+            'accountLink' => '#',
+            'wishlistsTitlePage' => Configuration::get('blockwishlist_WishlistPageName', $this->context->language->id),
+            'newWishlistCTA' => Configuration::get('blockwishlist_CreateButtonLabel', $this->context->language->id),
+        ]
+      );
+
         $this->context->controller->registerJavascript(
           'blockwishlistController',
           'modules/blockwishlist/public/wishlistcontainer.bundle.js',

--- a/controllers/front/lists.php
+++ b/controllers/front/lists.php
@@ -31,6 +31,8 @@ class BlockWishlistListsModuleFrontController extends ModuleFrontController
         $this->context->smarty->assign(
         [
             'url' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'getAllWishlist']),
+            'renameUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'renameWishlist']),
+            'shareUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'getUrlByIdWishlist']),
             'accountLink' => '#',
             'wishlistsTitlePage' => Configuration::get('blockwishlist_WishlistPageName', $this->context->language->id),
             'newWishlistCTA' => Configuration::get('blockwishlist_CreateButtonLabel', $this->context->language->id),

--- a/views/templates/hook/displayHeader.tpl
+++ b/views/templates/hook/displayHeader.tpl
@@ -24,9 +24,8 @@
   {include file="module:blockwishlist/views/templates/components/toast.tpl"}
 {else}
   {include file="module:blockwishlist/views/templates/components/modals/add-to-wishlist.tpl" url=$url addUrl=$addUrl newWishlistCTA=$newWishlistCTA}
+  {include file="module:blockwishlist/views/templates/components/modals/delete.tpl" listUrl=$deleteListUrl productUrl=$deleteProductUrl}
   {include file="module:blockwishlist/views/templates/components/modals/create.tpl" url=$createUrl}
-  {include file="module:blockwishlist/views/templates/components/modals/delete.tpl" productUrl=$deleteProductUrl}
   {include file="module:blockwishlist/views/templates/components/modals/login.tpl"}
   {include file="module:blockwishlist/views/templates/components/toast.tpl"}
 {/if}
-

--- a/views/templates/pages/lists.tpl
+++ b/views/templates/pages/lists.tpl
@@ -31,6 +31,9 @@
     data-share-text="{l s='Share' d='Modules.Blockwishlist.Shop'}"
     data-add-text="{$newWishlistCTA}"
   ></div>
+
+  {include file="module:blockwishlist/views/templates/components/modals/share.tpl" url=$shareUrl}
+  {include file="module:blockwishlist/views/templates/components/modals/rename.tpl" url=$renameUrl}
 {/block}
 
 

--- a/views/templates/pages/lists.tpl
+++ b/views/templates/pages/lists.tpl
@@ -31,12 +31,6 @@
     data-share-text="{l s='Share' d='Modules.Blockwishlist.Shop'}"
     data-add-text="{$newWishlistCTA}"
   ></div>
-
-  {include file="module:blockwishlist/views/templates/components/modals/create.tpl" url=$createUrl}
-  {include file="module:blockwishlist/views/templates/components/modals/delete.tpl" listUrl=$deleteListUrl productUrl=$deleteProductUrl}
-  {include file="module:blockwishlist/views/templates/components/modals/share.tpl" url=$shareUrl}
-  {include file="module:blockwishlist/views/templates/components/modals/rename.tpl" url=$renameUrl}
-  {include file="module:blockwishlist/views/templates/components/toast.tpl"}
 {/block}
 
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When you go to your wishlist lists, when you click on create, it open 2 modals
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on my wishlist page and try to click on Create, then close the modal, it should works fine
| Possible impacts? | Wishlist page usage

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
