### PR TITLE
Number of products on wishlist page 

### DIFF
--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -168,7 +168,7 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
         if ('products' === $type) {
             $sortOrder = $query->getSortOrder()->toLegacyOrderBy(true);
             $querySearch->orderBy($sortOrder . ' ' . $query->getSortOrder()->toLegacyOrderWay());
-            $querySearch->limit(((int) $query->getPage() - 1) * (int) $query->getResultsPerPage(), (int) $query->getResultsPerPage());
+            $querySearch->limit((int) $query->getResultsPerPage(), ((int) $query->getPage() - 1) * (int) $query->getResultsPerPage());
             $products = $this->db->executeS($querySearch);
 
             if (empty($products)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When we have a restriction by productshown on wishlist view page the number of products that shows is not corect
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     |  no
| Ticket?      | Fixes https://github.com/PrestaShop/PrestaShop/issues/28164
| How to test?      | Go to the backoffice, configure the number of products to show in list, add more products in wishlist then that number, in list view yyou will see that the number of products in paginated in wrong way. See here https://drive.google.com/file/d/1lv2MVH6wTiH3reIKj-SHHHAMWMMvKViQ/view
| Possible impacts? | View wishlist page.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->