### PR TITLE
Fetch the default picture if a product has no image defined

### DIFF
--- a/src/Calculator/StatisticsCalculator.php
+++ b/src/Calculator/StatisticsCalculator.php
@@ -182,10 +182,9 @@ class StatisticsCalculator
 
         $presenterFactory = new ProductPresenterFactory($this->context);
         $presentationSettings = $presenterFactory->getPresentationSettings();
+        $imageRetriever = new ImageRetriever($this->context->link);
         $presenter = new ProductPresenter(
-            new ImageRetriever(
-                $this->context->link
-            ),
+            $imageRetriever,
             $this->context->link,
             new PriceFormatter(),
             new ProductColorsRetriever(),
@@ -202,6 +201,9 @@ class StatisticsCalculator
             if ($key == 'embedded_attributes') {
                 $imgDetails = $value['cover'];
             }
+        }
+        if (!$imgDetails) {
+            $imgDetails = $imageRetriever->getNoPictureImage($this->context->language);
         }
 
         return $imgDetails;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fetch the default picture if a product has no image defined
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#28131
| How to test?      | Cf. PrestaShop/PrestaShop#28131


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
