### PR TITLE
Fix modal display block

### DIFF
--- a/_dev/front/js/components/Create/Create.vue
+++ b/_dev/front/js/components/Create/Create.vue
@@ -144,7 +144,6 @@
   .wishlist {
     &-create {
       .wishlist-modal {
-        display: block;
         opacity: 0;
         pointer-events: none;
         z-index: 0;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In some occasions this modal it's on top of page, and cannot click on products, buttons....
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28565
| How to test?      | Just check if modal create wish list its display block by default

PLEASE, I CANNOT TEST IT, BECAUSE I HAVE VS2022 AND THIS MODULE USES NODE-SASS V5 WHICH APART FROM Being DEPRECATED IT USES AN OLD NODE-GYP WHICH CANNOT RECOGNIZE VS2022 C++ BUILD TOOLS
ANYWAY, SUCH A SMALL CHANGE SHOULDN BE Too MUCH PROBLEM

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
