### PR TITLE
Product dupplication on wishlist view

### DIFF
--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -158,7 +158,8 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
         if (Group::isFeatureActive()) {
             $groups = FrontController::getCurrentCustomerGroups();
             $sqlGroups = false === empty($groups) ? 'IN (' . implode(',', $groups) . ')' : '=' . (int) Group::getCurrent()->id;
-            $querySearch->leftJoin('category_group', 'cg', 'cp.`id_category` = cg.`id_category` AND cg.`id_group`' . $sqlGroups);
+            $querySearch->where('cp.id_category in (SELECT cg.`id_category` FROM `ps_category_group` `cg` where cp.`id_category` = cg.`id_category` AND cg.`id_group` '.$sqlGroups.')');
+
         }
 
         $querySearch->where('wp.id_wishlist = ' . (int) $this->wishList->id);


### PR DESCRIPTION
Replace Left join on table Category_group by a nested request with same condition to avoid product line duplication if customer are on many group


| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Replace Left join on table Category_group by a nested request with same condition to avoid product line duplication if customer are on many group
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | look wishlist with Group::iisFeatureActive() and with customer acount with many group.
| Possible impacts? | The function are only use on wishlist view controller.
