### PR TITLE
Remove forbidden error message from core template

### DIFF
--- a/controllers/front/view.php
+++ b/controllers/front/view.php
@@ -85,7 +85,7 @@ class BlockWishlistViewModuleFrontController extends ProductListingFrontControll
                 [],
                 'Modules.Blockwishlist.Shop'
             );
-            $this->setTemplate('errors/forbidden');
+            $this->template = 'module:blockwishlist/views/templates/errors/forbidden.tpl';
 
             return;
         }

--- a/views/templates/errors/forbidden.tpl
+++ b/views/templates/errors/forbidden.tpl
@@ -1,0 +1,29 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+{extends file='errors/forbidden.tpl'}
+
+{block name='content'}
+
+{/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since PrestaShop/PrestaShop#27095, the `errors/forbidden.tpl` template has now content. As blockwishlist was using it, it now displays content as well. This PR fixes it by extending the core template and removing the content.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#28832
| How to test?      | Please see PrestaShop/PrestaShop#28832
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
