### PR TITLE
Add max lenght to avoid bad display in front office

### DIFF
--- a/src/Type/ConfigurationType.php
+++ b/src/Type/ConfigurationType.php
@@ -36,7 +36,14 @@ class ConfigurationType extends AbstractType
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
-                ],         
+                ],
+                'options' => [
+                    'constraints' => [
+                        new Length([
+                            'max' => 180,
+                        ]),
+                    ],
+                ]
             ])
             ->add('CreateButtonLabel', TranslatableType::class, [
                 // we'll have text area that is translatable
@@ -44,13 +51,27 @@ class ConfigurationType extends AbstractType
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
-             ])
+                'options' => [
+                    'constraints' => [
+                        new Length([
+                            'max' => 180,
+                        ]),
+                    ],
+                ]
+            ])
             ->add('WishlistPageName', TranslatableType::class, [
                 // we'll have text area that is translatable
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
+                'options' => [
+                    'constraints' => [
+                        new Length([
+                            'max' => 180,
+                        ]),
+                    ],
+                ]
             ]);
     }
 }

--- a/src/Type/ConfigurationType.php
+++ b/src/Type/ConfigurationType.php
@@ -36,14 +36,7 @@ class ConfigurationType extends AbstractType
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
-                ],
-                'options' => [
-                    'constraints' => [
-                        new Length([
-                            'max' => 180,
-                        ]),
-                    ],
-                ]
+                ],         
             ])
             ->add('CreateButtonLabel', TranslatableType::class, [
                 // we'll have text area that is translatable
@@ -51,27 +44,13 @@ class ConfigurationType extends AbstractType
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
-                'options' => [
-                    'constraints' => [
-                        new Length([
-                            'max' => 180,
-                        ]),
-                    ],
-                ]
-            ])
+             ])
             ->add('WishlistPageName', TranslatableType::class, [
                 // we'll have text area that is translatable
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
-                'options' => [
-                    'constraints' => [
-                        new Length([
-                            'max' => 180,
-                        ]),
-                    ],
-                ]
             ]);
     }
 }

--- a/src/Type/ConfigurationType.php
+++ b/src/Type/ConfigurationType.php
@@ -37,6 +37,13 @@ class ConfigurationType extends AbstractType
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
+                'options' => [
+                    'constraints' => [
+                        new Length([
+                            'max' => 180,
+                        ]),
+                    ],
+                ]
             ])
             ->add('CreateButtonLabel', TranslatableType::class, [
                 // we'll have text area that is translatable
@@ -44,6 +51,13 @@ class ConfigurationType extends AbstractType
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
+                'options' => [
+                    'constraints' => [
+                        new Length([
+                            'max' => 180,
+                        ]),
+                    ],
+                ]
             ])
             ->add('WishlistPageName', TranslatableType::class, [
                 // we'll have text area that is translatable
@@ -51,6 +65,13 @@ class ConfigurationType extends AbstractType
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
+                'options' => [
+                    'constraints' => [
+                        new Length([
+                            'max' => 180,
+                        ]),
+                    ],
+                ]
             ]);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This Pull Request add max length to Configuration Form  to avoid bad display in front office
| Type?             |  improvement
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28326
| How to test?      | Go to BO > Module manager > Wishlist Module <br/>Set all fields with too long-expression (more than 180 characters)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
