### PR TITLE
Fix for Behavior while logout on wishlist is not consistent

### DIFF
--- a/controllers/front/view.php
+++ b/controllers/front/view.php
@@ -78,16 +78,14 @@ class BlockWishlistViewModuleFrontController extends ProductListingFrontControll
         parent::init();
 
         if (false === $this->customerAccess->hasReadAccessToWishlist($this->wishlist)) {
-            header('HTTP/1.1 403 Forbidden');
-            header('Status: 403 Forbidden');
-            $this->errors[] = $this->trans(
-                'You do not have access to this wishlist.',
-                [],
-                'Modules.Blockwishlist.Shop'
-            );
-            $this->template = 'module:blockwishlist/views/templates/errors/forbidden.tpl';
-
-            return;
+            $this->errors = [
+                $this->trans(
+                    'You do not have access to this wishlist.',
+                    [],
+                    'Modules.Blockwishlist.Shop'
+                ),
+            ];
+            $this->redirectWithNotifications('index.php');
         }
 
         $this->context->smarty->assign(

--- a/tests/phpstan.sh
+++ b/tests/phpstan.sh
@@ -14,7 +14,7 @@ docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/presta
 # Clear previous instance of the module in the PrestaShop volume
 echo "Clear previous module"
 
-docker exec -t temp-ps rm -rf /var/www/html/modules/blockwishlist
+docker exec -tid temp-ps rm -rf /var/www/html/modules/blockwishlist
 
 # Run a container for PHPStan, having access to the module content and PrestaShop sources.
 # This tool is outside the composer.json because of the compatibility with PHP 5.6


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Redirect to the homepage when trying to access an unauthorized wishlist with the correct error message
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29654.
| How to test?      | Try to access `/module/blockwishlist/view?id_wishlist=1` when being logged off
| Possible impacts? | The blockwishlist module
