### PR TITLE
Fix Issue : FO / Blockwishlist - Translations are not take in account for "Wishlist default title" part

### DIFF
--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -312,6 +312,7 @@ class BlockWishList extends Module
             'deleteProductUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'deleteProductFromWishlist']),
             'addUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'addProductToWishlist']),
             'newWishlistCTA' => Configuration::get('blockwishlist_CreateButtonLabel', $this->context->language->id),
+            'defaultWishlistTitle' => Configuration::get('blockwishlist_WishlistDefaultTitle', $this->context->language->id)
         ]);
 
         return $this->fetch('module:blockwishlist/views/templates/hook/displayHeader.tpl');

--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -312,7 +312,7 @@ class BlockWishList extends Module
             'deleteProductUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'deleteProductFromWishlist']),
             'addUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'addProductToWishlist']),
             'newWishlistCTA' => Configuration::get('blockwishlist_CreateButtonLabel', $this->context->language->id),
-            'wishlistsTitlePage' => Configuration::get('blockwishlist_WishlistPageName', $this->context->language->id)
+            'wishlistsTitlePage' => Configuration::get('blockwishlist_WishlistPageName', $this->context->language->id),
         ]);
 
         return $this->fetch('module:blockwishlist/views/templates/hook/displayHeader.tpl');

--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -312,7 +312,7 @@ class BlockWishList extends Module
             'deleteProductUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'deleteProductFromWishlist']),
             'addUrl' => $this->context->link->getModuleLink('blockwishlist', 'action', ['action' => 'addProductToWishlist']),
             'newWishlistCTA' => Configuration::get('blockwishlist_CreateButtonLabel', $this->context->language->id),
-            'defaultWishlistTitle' => Configuration::get('blockwishlist_WishlistDefaultTitle', $this->context->language->id)
+            'wishlistsTitlePage' => Configuration::get('blockwishlist_WishlistPageName', $this->context->language->id)
         ]);
 
         return $this->fetch('module:blockwishlist/views/templates/hook/displayHeader.tpl');

--- a/views/templates/components/modals/add-to-wishlist.tpl
+++ b/views/templates/components/modals/add-to-wishlist.tpl
@@ -34,7 +34,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">
-            {l s='Add to wishlist' d='Modules.Blockwishlist.Shop'}
+            {$defaultWishlistTitle}
           </h5>
           <button
             type="button"
@@ -68,7 +68,7 @@
     </div>
   </div>
 
-  <div 
+  <div
     class="modal-backdrop fade"
     {literal}
       :class="{in: !isHidden}"

--- a/views/templates/components/modals/add-to-wishlist.tpl
+++ b/views/templates/components/modals/add-to-wishlist.tpl
@@ -34,7 +34,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">
-            {$defaultWishlistTitle}
+            {$wishlistsTitlePage}
           </h5>
           <button
             type="button"


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Updated the code to get the default wishlist modal title from the configuration
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29212 (partially)
| How to test?      | Set  a default title in the configuration of the module in the backoffice, open the wishlist modal on a product page and check that the good title is shown.
| Possible impacts? | I don't think there is any impact.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
