### PR TITLE
fix sql to get count or products

### DIFF
--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -136,7 +136,7 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
                 $querySearch->select('product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.`id_product_attribute`,0) AS id_product_attribute');
             }
         } else {
-            $querySearch->select('COUNT(wp.id_product)');
+            $querySearch->select('COUNT(DISTINCT wp.id_product)');
         }
 
         $querySearch->from('product', 'p');
@@ -173,6 +173,8 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
                 $querySearch->orderBy($sortOrder . ' ' . $sortWay);
             }
             $querySearch->limit((int) $query->getResultsPerPage(), ((int) $query->getPage() - 1) * (int) $query->getResultsPerPage());
+            $querySearch->groupBy('p.id_product');
+
             $products = $this->db->executeS($querySearch);
 
             if (empty($products)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | There was an issue when a product category belongs to multiple groups, it was duplicating the number of product in returned by the sql query.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29043
| How to test?      |  See the step in the parent issue
| Possible impacts? | On the list of products on the wishlist.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
