### PR TITLE
Fix overflow filter select on small screens

### DIFF
--- a/_dev/front/js/container/ProductsListContainer/ProductsListContainer.vue
+++ b/_dev/front/js/container/ProductsListContainer/ProductsListContainer.vue
@@ -34,8 +34,8 @@
         class="sort-by-row"
         v-if="products.datas"
       >
-        <span class="col-sm-3 col-md-3 hidden-sm-down sort-by">{{ filter }}</span>
-        <div class="col-sm-9 col-xs-8 col-md-9 products-sort-order dropdown">
+        <span class="hidden-sm-down col-sm-3 col-md-3 sort-by">{{ filter }}</span>
+        <div class="col-xs-12 col-sm-9 col-md-9 products-sort-order dropdown">
           <button
             class="btn-unstyle select-title"
             rel="nofollow"
@@ -346,6 +346,7 @@
 
           .sort-by-row {
             width: 100%;
+            min-width: 16.00rem;
           }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Decrease min-width of select-list's wrapper to fit with narrower screens (768px down to 288px)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop/issues/30070
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Apply PR changes.<br> In terminal rebuild assets.<br> In BO, Performance > Clear cache.<br> In FO, clear browser cache, then do check following the above issue's description.
