### PR TITLE
Fix modal padding

### DIFF
--- a/_dev/front/scss/_modal.scss
+++ b/_dev/front/scss/_modal.scss
@@ -59,7 +59,7 @@
     }
 
     &-body {
-      padding: 0.9375 1.875rem;
+      padding: 0.9375rem 1.875rem;
 
       .form-group {
         margin-bottom: 0;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Padding on `modal-body` is missing a unit so it doesn't work and causes misalignment with modal's header and footer.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | Trigger any wishlist modal eg. by adding product to the wishlist as a guest

### Before
![obraz](https://user-images.githubusercontent.com/5007456/220593215-418a06ff-e470-4e8c-bb79-c8ede810ea74.png)

### After
![obraz](https://user-images.githubusercontent.com/5007456/220593358-bbe64bc3-f709-4a7a-b37b-81608d074258.png)

