### PR TITLE
Update github actions for Node 14/16 - test

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
-          path: ${{ github.workspace }}
+          path: ${{ github.event.repository.name }}
 
   update_release_draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
-          path: ${{ runner.temp }}
+          path: ~/PrestaShop/modules/blockwishlist
 
   update_release_draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
-          path: ~/PrestaShop/modules/blockwishlist
+          path: /home/runner/work/blockwishlist/
 
   update_release_draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
-          path: /home/runner/work/blockwishlist/
+          path: ${{ github.workspace }}
       - run: echo "This workspace path:" ${{ github.workspace }}
   update_release_draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
-          path: ${{ github.workspace }}
+          path: ../
 
   update_release_draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
-          path: ${{ github.event.repository.name }}
+          path: ${{ runner.temp }}
 
   update_release_draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v3
 
       - name: Clone PrestaShop for core dependencies
         run: |
@@ -19,7 +19,7 @@ jobs:
           cd blockwishlist
 
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 
@@ -50,10 +50,10 @@ jobs:
         run: ~/.composer/vendor/bin/autoindex
 
       - name: Create & upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
-          path: ../
+          path: ${{ github.workspace }}
 
   update_release_draft:
     runs-on: ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
 
@@ -88,7 +88,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to GitHub Release
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           name: ${{ github.event.repository.name }}
           path: /home/runner/work/blockwishlist/
-
+      - run: echo "This workspace path:" ${{ github.workspace }}
   update_release_draft:
     runs-on: ubuntu-latest
     needs: [deploy]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
-          path: ../
+          path: ${{ github.workspace }}
 
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | as recommended at https://github.com/PrestaShop/blockwishlist/actions/runs/4298859500 <br>_(using Organization Build Release Github Action at https://github.com/PrestaShop/blockreassurance/pull/521 does not fix the deprecated issue because Organization GH Action is also deprecated :)_
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | See description above
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Automatic checks pass without warnings of Node 12 deprecation.