### PR TITLE
Fix babel-loader options & Upgrade webpack-cli from v3.3 to v4.3

### DIFF
--- a/.webpack/common.js
+++ b/.webpack/common.js
@@ -113,7 +113,7 @@ module.exports = {
             loader: 'babel-loader',
             options: {
               presets: [['@babel/preset-env', {useBuiltIns: 'usage', modules: false}]],
-              plugins: ['@babel/plugin-transform-runtime', '@babel/preset-env'],
+              plugins: ['@babel/plugin-transform-runtime'],
             },
           },
         ],

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "private": "true",
   "scripts": {
-    "build": "webpack --progress --colors --mode=production",
-    "dev": "webpack --progress --colors --debug --display-chunks --watch --mode=development",
+    "build": "webpack --progress --mode=production",
+    "dev": "webpack --progress --debug --display-chunks --watch --mode=development",
     "watch": "npm run dev",
     "lint": "eslint -c .eslintrc.js --ext .js,.vue .",
     "lint-fix": "eslint -c .eslintrc.js --ext .js,.vue . --fix",
@@ -78,7 +78,7 @@
     "vue-loader": "^15",
     "vue-style-loader": "^4.1.2",
     "webpack": "^4.46",
-    "webpack-cli": "^3.3.10",
+    "webpack-cli": "^4.3.1",
     "webpack-fix-style-only-entries": "^0.6.1",
     "webpack-merge": "^5.7.3"
   },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix: @babel/preset-env is not a plugin <br> Upgrade: webpack-cli from v3.3.10 to v4.3.1
| Type?             | bug fix / improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | check Description above i:)
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | `npm install` && `npm run build` can complete without error.
