### PR TITLE
Update github actions checkout and setup-node to v3

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -9,7 +9,7 @@ jobs:
                 node-versions: [ '14', '16' ]
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v3.1.0
             - uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-versions }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,15 +1,18 @@
 name: JS tests
 on: [push, pull_request]
 jobs:
-  js-linter:
-    name: JS linter
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.0.0
-
-      - name: lint js dependencies
-        uses: PrestaShopCorp/github-action-lint-js/14@master
-        with:
-          cmd: yarn
-          path: .
+    js-linter:
+        name: JS linter
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-versions: [ '14', '16' ]
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-versions }}
+            - run: npm install
+            - name: Lint
+              run: npm run lint


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Stop using deprecated https://github.com/PrestaShopCorp/github-action-lint-js
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue URL here}, Fixes #{another issue URL here}
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | JS test run successfully without warning about deprecated github actions
