### PR TITLE
Standardize upgrade files

### DIFF
--- a/upgrade/upgrade-0.3.0.php
+++ b/upgrade/upgrade-0.3.0.php
@@ -26,7 +26,7 @@ if (!defined('_PS_VERSION_')) {
  *
  * @return bool
  */
-function upgrade_module_0_3($module)
+function upgrade_module_0_3_0($module)
 {
     return $module->registerHook('displayProductListFunctionalButtons')
         && $module->registerHook('top');

--- a/upgrade/upgrade-1.1.0.php
+++ b/upgrade/upgrade-1.1.0.php
@@ -26,7 +26,7 @@ if (!defined('_PS_VERSION_')) {
  *
  * @return bool
  */
-function upgrade_module_1_1($module)
+function upgrade_module_1_1_0($module)
 {
     $result = true;
     $list_fields = Db::getInstance()->executeS('SHOW FIELDS FROM `' . _DB_PREFIX_ . 'wishlist`');


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix issues with upgrade file names. They could be executed by the core when not wanted.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Problems found when testing upgrades of some modules.
| Sponsor company   | 
| How to test?      | No need.


| Current name | Correct name | What is wrong
| ------------------| ------------- | -------------
| blockwishlist\upgrade\upgrade-0.3.php | blockwishlist\upgrade\upgrade-0.3.0.php | Bad version format
| blockwishlist\upgrade\upgrade-1.1.php | blockwishlist\upgrade\upgrade-1.1.0.php | Bad version format






























































