### PR TITLE
Remove harmful inline styles

### DIFF
--- a/_dev/front/js/components/Create/Create.vue
+++ b/_dev/front/js/components/Create/Create.vue
@@ -139,21 +139,3 @@
     },
   };
 </script>
-
-<style lang="scss" type="text/scss">
-  .wishlist {
-    &-create {
-      .wishlist-modal {
-        opacity: 0;
-        pointer-events: none;
-        z-index: 0;
-
-        &.show {
-          opacity: 1;
-          pointer-events: all;
-          z-index: 1053;
-        }
-      }
-    }
-  }
-</style>

--- a/_dev/front/js/components/Delete/Delete.vue
+++ b/_dev/front/js/components/Delete/Delete.vue
@@ -156,22 +156,3 @@
     },
   };
 </script>
-
-<style lang="scss" type="text/scss">
-  .wishlist {
-    &-delete {
-      .wishlist-modal {
-        display: block;
-        opacity: 0;
-        pointer-events: none;
-        z-index: 0;
-
-        &.show {
-          opacity: 1;
-          pointer-events: all;
-          z-index: 1053;
-        }
-      }
-    }
-  }
-</style>

--- a/_dev/front/js/components/Login/Login.vue
+++ b/_dev/front/js/components/Login/Login.vue
@@ -65,17 +65,3 @@
     },
   };
 </script>
-
-<style lang="scss" type="text/scss">
-  .wishlist {
-    &-login {
-      .wishlist-modal {
-        z-index: 0;
-
-        &.show {
-          z-index: 1053;
-        }
-      }
-    }
-  }
-</style>

--- a/_dev/front/js/components/Rename/Rename.vue
+++ b/_dev/front/js/components/Rename/Rename.vue
@@ -112,22 +112,3 @@
     },
   };
 </script>
-
-<style lang="scss" type="text/scss" scoped>
-  .wishlist {
-    &-rename {
-      .wishlist-modal {
-        display: block;
-        opacity: 0;
-        pointer-events: none;
-        z-index: 0;
-
-        &.show {
-          opacity: 1;
-          pointer-events: all;
-          z-index: 1051;
-        }
-      }
-    }
-  }
-</style>

--- a/_dev/front/js/components/Share/Share.vue
+++ b/_dev/front/js/components/Share/Share.vue
@@ -111,22 +111,3 @@
     },
   };
 </script>
-
-<style lang="scss" type="text/scss">
-  .wishlist {
-    &-share {
-      .wishlist-modal {
-        display: block;
-        opacity: 0;
-        pointer-events: none;
-        z-index: 0;
-
-        &.show {
-          opacity: 1;
-          pointer-events: all;
-          z-index: 1053;
-        }
-      }
-    }
-  }
-</style>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |  Modals' inline styles caused them to be always active on the page, just invisible. They were blocking access to elements behind them on Hummingbird theme. Classic theme has different configuration of the footer where wishlist modals are hooked so the issue is hidden much better there and doesn't occur. These inline styles are just useless there. All required modals styles are already in .css file.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/hummingbird/issues/594 https://github.com/PrestaShop/PrestaShop/issues/35276
| Sponsor company   | -
| How to test?      | 1. Install Hummingbird theme on develop branch<br>2. Check if modals still block the center of the page.

![obraz](https://github.com/PrestaShop/blockwishlist/assets/5007456/41ac6fff-2064-4756-8e2b-06e7017d0d5d)

https://github.com/PrestaShop/PrestaShop/assets/5007456/4a92dd5a-9b20-4bc2-8b65-452fefd3def8

https://github.com/PrestaShop/blockwishlist/blob/dbaf532ed79a920c2522545d4fabd476ce17808f/_dev/front/scss/_modal.scss#L19-L29
