### PR TITLE
Fix [BUG] JavaScript Error on Product Pages with Combinations

### DIFF
--- a/_dev/front/js/components/Button/Button.vue
+++ b/_dev/front/js/components/Button/Button.vue
@@ -175,7 +175,7 @@
           // eslint-disable-next-line
           const itemsFiltered = productsAlreadyTagged.filter(
             (e) => parseInt(e.id_product, 10) === this.productId
-              && e.quantity.toString() === quantity.value
+              && (quantity ? e.quantity.toString() === quantity.value : true)
               && parseInt(e.id_product_attribute, 10) === this.idProductAttribute,
           );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixed a JavaScript TypeError on product pages with combinations ("Cannot read properties of null").
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #391
| Sponsor company   | 
| How to test?      | 
