### PR TITLE
Prevent attribute deletion from wiping all wishlists and statistics

### DIFF
--- a/classes/Statistics.php
+++ b/classes/Statistics.php
@@ -66,12 +66,17 @@ class Statistics extends ObjectModel
             return false;
         }
 
-        return Db::getInstance()->delete(
-            'blockwishlist_statistics',
-            ($id_product ? 'id_product = ' . (int) $id_product : '')
+        $where = ($id_product ? 'id_product = ' . (int) $id_product : '')
             . ($id_product && $id_product_attribute ? ' AND ' : '')
-            . ($id_product_attribute ? ' id_product_attribute = ' . (int) $id_product_attribute : '')
-        );
+            . ($id_product_attribute ? ' id_product_attribute = ' . (int) $id_product_attribute : '');
+
+        // Never run an unconstrained DELETE: a falsy identifier (e.g. id_product_attribute = 0 for a
+        // simple product) would otherwise build an empty WHERE clause and wipe the whole table.
+        if ('' === $where) {
+            return false;
+        }
+
+        return Db::getInstance()->delete('blockwishlist_statistics', $where);
     }
 
     /**
@@ -83,6 +88,9 @@ class Statistics extends ObjectModel
         $dbQuery->select('bws.id_product_attribute');
         $dbQuery->from('blockwishlist_statistics', 'bws');
         $dbQuery->leftJoin('product_attribute', 'pa', 'bws.id_product_attribute = pa.id_product_attribute');
+        // Only real combinations (> 0) can be orphaned. Simple products use id_product_attribute = 0,
+        // which never matches a product_attribute row and must not be treated as an orphan.
+        $dbQuery->where('bws.id_product_attribute > 0');
         $dbQuery->where('pa.id_product_attribute IS NULL');
         $productAttributes = Db::getInstance()->executeS($dbQuery);
 

--- a/classes/WishList.php
+++ b/classes/WishList.php
@@ -244,12 +244,17 @@ class WishList extends ObjectModel
             return false;
         }
 
-        return Db::getInstance()->delete(
-            'wishlist_product',
-            ($id_product ? 'id_product = ' . (int) $id_product : '')
+        $where = ($id_product ? 'id_product = ' . (int) $id_product : '')
             . ($id_product && $id_product_attribute ? ' AND ' : '')
-            . ($id_product_attribute ? ' id_product_attribute = ' . (int) $id_product_attribute : '')
-        );
+            . ($id_product_attribute ? ' id_product_attribute = ' . (int) $id_product_attribute : '');
+
+        // Never run an unconstrained DELETE: a falsy identifier (e.g. id_product_attribute = 0 for a
+        // simple product) would otherwise build an empty WHERE clause and wipe the whole table.
+        if ('' === $where) {
+            return false;
+        }
+
+        return Db::getInstance()->delete('wishlist_product', $where);
     }
 
     /**
@@ -261,6 +266,9 @@ class WishList extends ObjectModel
         $dbQuery->select('wp.id_product_attribute');
         $dbQuery->from('wishlist_product', 'wp');
         $dbQuery->leftJoin('product_attribute', 'pa', 'wp.id_product_attribute = pa.id_product_attribute');
+        // Only real combinations (> 0) can be orphaned. Simple products use id_product_attribute = 0,
+        // which never matches a product_attribute row and must not be treated as an orphan.
+        $dbQuery->where('wp.id_product_attribute > 0');
         $dbQuery->where('pa.id_product_attribute IS NULL');
         $productAttributes = Db::getInstance()->executeS($dbQuery);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Deleting **any** product attribute from the Back Office wiped the **entire** `ps_wishlist_product` and `ps_blockwishlist_statistics` tables (every customer's wishlist + all statistics). `hookActionAttributeDelete` calls `removeNonExistingProductAttributesFrom{Wishlist,Statistics}()`, whose `LEFT JOIN product_attribute ... WHERE pa.id_product_attribute IS NULL` lookup also matched **simple-product rows** (which use `id_product_attribute = 0`, never present in `product_attribute`). Each match called `removeProductFrom…(null, 0)`; with a `null` product and a falsy `0` attribute the helper built an **empty WHERE clause**, so `Db::delete()` executed `DELETE FROM ps_wishlist_product` (and the statistics table) unconstrained. Fix = (1) restrict the orphan lookups to real combinations (`id_product_attribute > 0`), and (2) guard the delete helpers so an empty WHERE clause can never run a table-wide DELETE.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #448.
| How to test?      | Put both a simple product (no combinations) and a combination product in a wishlist, then delete any attribute (e.g. a Size value) in BO → Catalog → Attributes & Features. Before this fix the whole wishlist table is emptied; after it, only rows pointing at a genuinely-deleted combination are removed. Deterministic repro: insert into `ps_wishlist_product` three rows with `id_product_attribute` = `0` (simple), a valid combination id, and a non-existent id (e.g. `999999`); call `WishList::removeNonExistingProductAttributesFromWishlist()`. Before: table emptied (3 → 0). After: `0` and the valid combination survive, only `999999` is removed; and `WishList::removeProductFromWishlist(null, 0)` returns `false` without deleting anything.
| Sponsor company   |
