### PR TITLE
Fix wishlist hiding all but one combination of the same product

### DIFF
--- a/src/Search/WishListProductSearchProvider.php
+++ b/src/Search/WishListProductSearchProvider.php
@@ -136,7 +136,7 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
                 $querySearch->select('product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.`id_product_attribute`,0) AS id_product_attribute');
             }
         } else {
-            $querySearch->select('COUNT(DISTINCT wp.id_product)');
+            ->select('COUNT(DISTINCT wp.id_product, wp.id_product_attribute)');
         }
 
         $querySearch->from('product', 'p');
@@ -173,7 +173,7 @@ class WishListProductSearchProvider implements ProductSearchProviderInterface
                 $querySearch->orderBy($sortOrder . ' ' . $sortWay);
             }
             $querySearch->limit((int) $query->getResultsPerPage(), ((int) $query->getPage() - 1) * (int) $query->getResultsPerPage());
-            $querySearch->groupBy('p.id_product');
+            ->groupBy('p.id_product, wp.id_product_attribute');
 
             $products = $this->db->executeS($querySearch);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | On the front-office wishlist page, when a customer added several combinations of the **same** product to a wishlist, only one of them was displayed (and the product counter was wrong). `WishListProductSearchProvider` grouped the product query by `p.id_product` only, collapsing every combination of a product into a single row, and counted `COUNT(DISTINCT wp.id_product)` instead of distinct combinations. This groups by the product **and** its combination and counts distinct `(id_product, id_product_attribute)` pairs, so every wishlisted combination is listed and counted.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#36453, fixes #441.
| How to test?  | FO > log into a customer account > add a product (e.g. the Hummingbird t-shirt) to a wishlist in one combination (size S / White), then add the **same** product in another combination (size M / White) to the same wishlist. Open the wishlist page. Before: only one of the two combinations is shown and the counter shows 1. After: both combinations are listed and the counter shows 2; removing one still shows the other. Verified at the SQL level with a wishlist holding two combinations of one product: the old `GROUP BY p.id_product` returns 1 row / `COUNT(DISTINCT id_product)` = 1, while grouping by `p.id_product, wp.id_product_attribute` returns 2 rows and `COUNT(DISTINCT id_product, id_product_attribute)` = 2. (blockwishlist has no PHPUnit harness, so this is a deterministic DB-level reproduction rather than a unit test.)
| Sponsor company | Boring Investments

