### PR TITLE
Fix release zip packaging so the module archive is attached to the release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -71,9 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare for Release
-        run: |
-          cd ${{ github.event.repository.name }}
-          zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }}
+        run: zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }}
 
       - name: Clean existing assets
         shell: bash
@@ -93,6 +91,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.release_info.outputs.upload_url }}
-          asset_path: ./${{ github.event.repository.name }}/${{ github.event.repository.name }}.zip
+          asset_path: ./${{ github.event.repository.name }}.zip
           asset_name: ${{ github.event.repository.name }}.zip
           asset_content_type: application/zip


### PR DESCRIPTION
| Questions          | Answers                                                                 |
|--------------------|-------------------------------------------------------------------------|
| Description?       | The `Build & Release draft` workflow failed at the *Prepare for Release* step, so no `blockwishlist.zip` was attached to the published release. `actions/download-artifact` extracts the artifact to `./blockwishlist/` (a single level containing the module files), but the step did `cd blockwishlist && zip -r blockwishlist.zip blockwishlist`, looking for a nested `blockwishlist/` folder that does not exist → `zip error: Nothing to do!` (exit code 12). This PR zips from the workspace root so the archive keeps `blockwishlist/` at its root, and points `asset_path` at the produced file. |
| Type?              | bug fix                                                                 |
| BC breaks?         | no                                                                      |
| Deprecations?      | no                                                                      |
| Fixed ticket?      | #508                                                                    |
| How to test?       | Trigger the release flow (merge to `master`): the `update_release_draft` job now produces `blockwishlist.zip` (module folder at the archive root) and attaches it to the release draft. |
| Sponsor company    | @PrestaShopCorp

The v4.0.0 release asset has been restored manually from the successful build artifact; this PR fixes the packaging so future releases attach the zip automatically.

#### Why it broke

The `cd`/`zip` logic was never modified — only the artifact action versions were bumped. The regression comes from `actions/download-artifact` **v3 → v4** (with the matching `upload-artifact` v3 → v4): in v3, downloading a named artifact without a `path` created a subfolder named after the artifact, yielding a double nesting `./blockwishlist/blockwishlist/` that the `cd … && zip … blockwishlist` step relied on. In v4+ the download extracts directly into the current directory (single level `./blockwishlist/`), so the nested folder the `zip` step looked for no longer exists → exit 12. Zipping from the workspace root (this PR) is correct regardless of that extraction behavior.


