### PR TITLE
Add a wishlists table to the customer page in the BO

### DIFF
--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -283,7 +283,16 @@ class BlockWishList extends Module
      */
     public function hookDisplayAdminCustomers(array $params)
     {
+        $id_customer = $params['id_customer'];
+        $wishlists = WishList::getAllWishListsByIdCustomer($id_customer);
+
+        foreach ($wishlists as $key => $wishlist) {
+            $wishlists[$key]['shareUrl'] = $this->context->link->getModuleLink('blockwishlist', 'view', ['token' => $wishlist['token']]);
+            $wishlists[$key]['listUrl'] = $this->context->link->getModuleLink('blockwishlist', 'view', ['id_wishlist' => $wishlist['id_wishlist']]);
+        }
+
         $this->smarty->assign([
+            'wishlists' => $wishlists,
             'blockwishlist' => $this->displayName,
         ]);
 

--- a/views/templates/hook/displayAdminCustomers.tpl
+++ b/views/templates/hook/displayAdminCustomers.tpl
@@ -17,15 +17,34 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  *}
 
-<div class="col">
-  <div class="card">
-    <h3 class="card-header">
-      <i class="material-icons">remove_red_eye</i>
-      {$blockwishlist|escape:'html':'UTF-8'}
-      <span class="badge badge-primary rounded">0</span>
-    </h3>
-    <div class="card-body">
-      {$blockwishlist|escape:'html':'UTF-8'}
+{if $wishlists|count > 0}
+  <div class="col">
+    <div class="card d-print-none">
+      <div class="card-header">
+        <i class="material-icons">remove_red_eye</i>
+        {$blockwishlist|escape:'html':'UTF-8'}
+        <span class="badge badge-primary rounded">{$wishlists|count}</span>
+      </div>
+
+      <div class="card-body">
+        <table class="table" id="customer-wishlist-list">
+          <thead>
+            <tr>
+              <th scope="col">{l s='Name' d='Modules.Blockwishlist.Admin'}</th>
+              <th scope="col">{l s='Products' d='Modules.Blockwishlist.Admin'}</th>
+              <th scope="col">{l s='Actions' d='Modules.Blockwishlist.Admin'}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {foreach from=$wishlists item=wishlist}
+              <tr>
+                <td>{$wishlist.name|escape:'html':'UTF-8'}</td>
+                <td>{$wishlist.nbProducts}</td>
+                <td><a href="{$wishlist.shareUrl}" target="_blank">{l s='View' d='Modules.Blockwishlist.Admin'}</a></td>
+            {/foreach}
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
-</div>
+{/if}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Display the list of wishlists on the customer page in the Back Office.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | Log in to the front office. Add a few wishlists. Go to your account view in the back office.

<img width="1662" height="345" alt="obraz" src="https://github.com/user-attachments/assets/0243b8cb-040f-4dbb-861f-f69baadda935" />
