### PR TITLE
Show the customer's wishlists on the back office customer page

### DIFF
--- a/blockwishlist.php
+++ b/blockwishlist.php
@@ -283,8 +283,17 @@ class BlockWishList extends Module
      */
     public function hookDisplayAdminCustomers(array $params)
     {
+        $wishlists = [];
+
+        if (!empty($params['id_customer'])) {
+            // The query scopes itself to the current shop, or shop group, so the block shows the
+            // wishlists that belong to the context the employee is looking at.
+            $wishlists = WishList::getAllWishlistsByIdCustomer((int) $params['id_customer']) ?: [];
+        }
+
         $this->smarty->assign([
             'blockwishlist' => $this->displayName,
+            'wishlists' => $wishlists,
         ]);
 
         return $this->fetch('module:blockwishlist/views/templates/hook/displayAdminCustomers.tpl');

--- a/views/templates/hook/displayAdminCustomers.tpl
+++ b/views/templates/hook/displayAdminCustomers.tpl
@@ -22,10 +22,34 @@
     <h3 class="card-header">
       <i class="material-icons">remove_red_eye</i>
       {$blockwishlist|escape:'html':'UTF-8'}
-      <span class="badge badge-primary rounded">0</span>
+      <span class="badge badge-primary rounded">{$wishlists|@count}</span>
     </h3>
     <div class="card-body">
-      {$blockwishlist|escape:'html':'UTF-8'}
+      {if $wishlists}
+        <table class="table">
+          <thead>
+            <tr>
+              <th>{l s='Name' d='Modules.Blockwishlist.Admin'}</th>
+              <th class="text-right">{l s='Products' d='Modules.Blockwishlist.Admin'}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {foreach from=$wishlists item=wishlist}
+              <tr>
+                <td>
+                  {$wishlist.name|escape:'html':'UTF-8'}
+                  {if $wishlist.default}
+                    <span class="badge badge-secondary rounded">{l s='Default' d='Modules.Blockwishlist.Admin'}</span>
+                  {/if}
+                </td>
+                <td class="text-right">{$wishlist.nbProducts|intval}</td>
+              </tr>
+            {/foreach}
+          </tbody>
+        </table>
+      {else}
+        <p class="mb-0">{l s='This customer has no wishlist.' d='Modules.Blockwishlist.Admin'}</p>
+      {/if}
     </div>
   </div>
 </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?    | The card the module renders through `displayAdminCustomers` never looked the customer up. `hookDisplayAdminCustomers()` assigned only `$this->displayName`, and the template printed a hardcoded `0` badge with the module name as its body, so the block was empty for every customer no matter what they had saved - which is what https://github.com/PrestaShop/PrestaShop/issues/28572 meant by "not implemented". It now fetches the wishlists and lists them with their product counts, and says so explicitly when there are none.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | Fixes https://github.com/PrestaShop/PrestaShop/issues/27143
| How to test?    | Sign in on the front office, add products to a wishlist, then open that customer in Customers > view. Before: the Wishlist card shows a `0` badge and the word "Wishlist". After: it lists each wishlist with the number of products in it, the default one first, and shows "This customer has no wishlist." for a customer who has none.
| Sponsor company |

> blockwishlist has **no** `PULL_REQUEST_TEMPLATE.md` - table shape taken from an earlier PR in this repo.
> Confirm against a recent merged one at publish time.

### Measured, on the real hook

`Hook::exec('displayAdminCustomers', ['id_customer' => …])` against a seeded wishlist of 2 products:

```
                                   badge   body
shipped                            0       "Wishlist"        (the module display name)
patched, customer with 1 list      1       table: "Probe27143 list" -> 2 products
patched, customer with none        0       "This customer has no wishlist."
patched, hook called with no id    0       "This customer has no wishlist."   (no error)
```

### Reused rather than written

`WishList::getAllWishlistsByIdCustomer()` already existed and already returns `nbProducts` per list plus
the `default` flag, and already restricts itself to `Shop::getContextShopID()` or the context shop group.
So the hook is four lines and the multistore scoping comes for free rather than being re-implemented -
worth saying in the PR, since a reviewer will otherwise wonder why no shop handling is visible.

### Gates

- `php -l` clean; module's own `php-cs-fixer` (PrestaShop coding standard) reports no violations.
- blockwishlist ships **no PHPUnit suite** (`tests/` holds `js`, `php` (phpstan) and `UI`), so the measured
  RED -> GREEN above stands in for a unit test, as with ps_emailalerts.
- Not run: the module's PHPStan and the UI campaign.

### Context worth carrying to the PR

PrestaShop SA said on the issue (ibahloul-ps, 2025-02-06) that they would not fix it and invited a community
PR; the issue is labelled `Ready`. Three later reports were closed as duplicates of it: https://github.com/PrestaShop/PrestaShop/issues/28572, https://github.com/PrestaShop/PrestaShop/issues/34853, https://github.com/PrestaShop/PrestaShop/issues/35844.
