### PR TITLE
Sort the wishlist by when products were added, as the page says it does

### DIFF
--- a/controllers/front/view.php
+++ b/controllers/front/view.php
@@ -148,13 +148,11 @@ class BlockWishlistViewModuleFrontController extends ProductListingFrontControll
     protected function getProductSearchQuery()
     {
         $query = new ProductSearchQuery();
-        $query->setSortOrder(
-            new SortOrder(
-                'product',
-                Tools::getProductsOrder('by'),
-                Tools::getProductsOrder('way')
-            )
-        );
+        // The page advertises "Last added" as its sort and offers no other one, so that is what it has to
+        // apply by default. Falling back to the catalogue order (PS_PRODUCTS_ORDER_BY, position on a stock
+        // install) ordered the wishlist by where each product sits in its default category instead, which
+        // is unrelated to when it was added.
+        $query->setSortOrder(new SortOrder('wishlist_product', 'id_wishlist_product', 'DESC'));
 
         return $query;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?    | The wishlist page advertises "Last added" as its sort - `products-list.tpl` renders `data-default-sort="{l s='Last added'}"` and `WishListProductSearchProvider` offers that as the only sort order - but `WishlistViewController::getProductSearchQuery()` built the query with the **catalogue** ordering instead, `Tools::getProductsOrder('by'/'way')`, which is `PS_PRODUCTS_ORDER_BY` and resolves to `cp.position` ascending on a stock install. The list therefore came back ordered by where each product sits in its default category, which is unrelated to when it was added, so adding a product could place it anywhere in the list.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | Fixes PrestaShop/PrestaShop#36496
| How to test?    | Add three products to a wishlist in a known order and open the wishlist. They appear newest first, and a newly added product appears at the top. Before this change the order followed each product's position in its default category, so the newest product could appear anywhere.
| Sponsor company |

### Verified rather than assumed

The replacement is the same `SortOrder` the provider already exposes, and its emitted clause was checked against core:

```
SortOrder('wishlist_product', 'id_wishlist_product', 'DESC')
  toLegacyOrderBy(true) = "id_wishlist_product"      Validate::isOrderBy  = true
  toLegacyOrderWay()    = "desc"                     Validate::isOrderWay = true

current default -> "cp.position asc"
```

The column is unambiguous because the provider inner joins `wishlist_product` as `wp`, and `cp` is only there because the provider left joins `category_product` for the category filter - so the old clause was valid SQL, just answering the wrong question.

Ordering by a column outside the `GROUP BY` is fine here: PrestaShop clears the session `sql_mode` on connect (`SET SESSION sql_mode = ''` in both `DbPDO` and `DbMySQLi`), so `ONLY_FULL_GROUP_BY` is not in force, and the existing "Last added" option already relies on this.

### Why the report was hard to reproduce

The outcome depended entirely on the catalogue positions of the products chosen for the test, which is why @Progi1984 saw it and @florine2623 did not. `public/` assets are untouched: this is a PHP controller change with no front-end build involved.